### PR TITLE
52 fix provider details call

### DIFF
--- a/app/poros/detailed_provider.rb
+++ b/app/poros/detailed_provider.rb
@@ -27,14 +27,24 @@ class DetailedProvider
     @lat = data[:locations].first[:latitude]
     @lon = data[:locations].first[:longitude]
     @website = data[:url]
-    @phone = find_phone(data[:locations].first)
+    @phone = get_phone(data)
     @fees = data[:services].first[:fees]
     @schedule = data[:locations].first[:schedule]
   end
 
-  def find_phone(data)
-    phone = data[:phone].select do |phone|
-      phone[:number] if phone[:type] == "Main Number"
+  def get_phone(data)
+    if data[:services].first.has_key?(:phone)
+      find_phone(data[:services].first[:phone])
+    elsif data[:locations].first.has_key?(:phone)
+      find_phone(data[:locations].first[:phone])
+    else
+      "Phone number not available"
+    end
+  end
+
+  def find_phone(phone_numbers)
+    phone = phone_numbers.select do |phone|
+      phone if phone[:type].downcase.include?('main') 
     end.first
     phone[:number]
   end

--- a/spec/fixtures/vcr_cassettes/Search/GET_/api/v0/provider_details/_id/When_a_valid_ID_is_used/should_return_the_details_of_a_provider.json
+++ b/spec/fixtures/vcr_cassettes/Search/GET_/api/v0/provider_details/_id/When_a_valid_ID_is_used/should_return_the_details_of_a_provider.json
@@ -57,6 +57,64 @@
         }
       },
       "recorded_at": "Sat, 16 Sep 2023 15:49:47 GMT"
+    },
+    {
+      "request": {
+        "method": "get",
+        "uri": "https://api.211.org/search/v1/api/ServiceAtLocation?idServiceAtLocation=211colorad-a0h4T000003fVncQAE",
+        "body": {
+          "encoding": "US-ASCII",
+          "string": ""
+        },
+        "headers": {
+          "Api-Key": [
+            "MY_SECRET_TOKEN"
+          ],
+          "User-Agent": [
+            "Faraday v2.7.11"
+          ],
+          "Accept-Encoding": [
+            "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+          ],
+          "Accept": [
+            "*/*"
+          ]
+        }
+      },
+      "response": {
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "headers": {
+          "Content-Length": [
+            "7179"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "Powered-By": [
+            "211 National Data Platform"
+          ],
+          "View-Data": [
+            "{\"idOrganization\":\"211colorad-0014T000004o6I3QAI\",\"idService\":\"211colorad-a0E4T000000NjbOUAS\",\"idLocation\":\"211colorad-a014T000004ehEEQAY\",\"idServiceAtLocation\":\"211colorad-a0h4T000003fVncQAE\",\"nameOrganization\":\"NEXTCARE URGENT CARE\",\"nameService\":\"MEDICAL CARE\",\"location\":{\"city\":\"Broomfield\",\"county\":\"Broomfield County\",\"stateProvince\":\"CO\",\"postalCode\":\"80020\",\"country\":\"United States\",\"latitude\":\"39.915035\",\"longitude\":\"-105.045715\"},\"serviceTaxonomyCodes\":[\"LN-8500\",\"LE\",\"LV-6800\",\"LT-3400.2500\"]}"
+          ],
+          "Request-Context": [
+            "appId=cid-v1:f765b36d-b251-47fd-848a-736b908cb0fe"
+          ],
+          "Date": [
+            "Sat, 16 Sep 2023 18:31:40 GMT"
+          ]
+        },
+        "body": {
+          "encoding": "ASCII-8BIT",
+          "string": "[\r\n  {\r\n    \"idOrganization\": \"211colorad-0014T000004o6I3QAI\",\r\n    \"name\": \"NEXTCARE URGENT CARE\",\r\n    \"alternateName\": null,\r\n    \"description\": \"<p>Provides urgent care services.</p>\",\r\n    \"url\": \"http://nextcare.com\",\r\n    \"taxStatus\": null,\r\n    \"taxId\": null,\r\n    \"yearIncorporated\": null,\r\n    \"legalStatus\": \"Commercial\",\r\n    \"services\": [\r\n      {\r\n        \"idService\": \"211colorad-a0E4T000000NjbOUAS\",\r\n        \"idOrganization\": \"211colorad-0014T000004o6I3QAI\",\r\n        \"name\": \"MEDICAL CARE\",\r\n        \"alternateName\": null,\r\n        \"description\": \"<p>Assists with:</p><ul><li>Common illnesses</li><li>Minor injuries</li><li>Physicals</li><li>Pediatrics</li><li>X-rays</li><li>Lab services</li><li>Immunizations</li></ul>\",\r\n        \"email\": null,\r\n        \"url\": \"http://nextcare.com\",\r\n        \"status\": \"active\",\r\n        \"applicationProcess\": \"Call or visit the website to schedule an appointment or for more information.\",\r\n        \"waitTime\": null,\r\n        \"fees\": \"<p>Medical Care Fees, call for current fees.</p>\",\r\n        \"accreditations\": null,\r\n        \"schedule\": \"Hours Vary (By Location)\",\r\n        \"language\": \"Spanish,English\",\r\n        \"serviceArea\": [\r\n          {\r\n            \"idServiceArea\": \"4574159455354165521\",\r\n            \"city\": null,\r\n            \"county\": null,\r\n            \"stateProvince\": \"Colorado\",\r\n            \"country\": \"United States\"\r\n          }\r\n        ],\r\n        \"eligibility\": \"No restrictions applied <BR /><br>Area Served:<BR>Statewide\",\r\n        \"document\": \"<p>Must provide:</p><ul><li>Insurance card</li><li>Photo ID</li><li>Co-pay</li></ul>\",\r\n        \"contact\": [],\r\n        \"phone\": [\r\n          {\r\n            \"idPhone\": \"7035447290392141485\",\r\n            \"number\": \"(888) 381-4858 (Customer Service\",\r\n            \"extension\": null,\r\n            \"type\": \"Main\",\r\n            \"description\": null,\r\n            \"name\": null\r\n          }\r\n        ],\r\n        \"taxonomy\": [\r\n          {\r\n            \"idTaxonomy\": \"2297018763978133250\",\r\n            \"code\": \"LN-8500\",\r\n            \"term\": \"Urgent Care Centers\",\r\n            \"nameLevel1\": \"Health Care\",\r\n            \"nameLevel2\": \"Outpatient Health Facilities\",\r\n            \"nameLevel3\": \"Urgent Care Centers\",\r\n            \"nameLevel4\": null,\r\n            \"nameLevel5\": null,\r\n            \"nameLevel6\": null\r\n          },\r\n          {\r\n            \"idTaxonomy\": \"2871651178407837232\",\r\n            \"code\": \"LE\",\r\n            \"term\": \"General Medical Care\",\r\n            \"nameLevel1\": \"Health Care\",\r\n            \"nameLevel2\": \"General Medical Care\",\r\n            \"nameLevel3\": null,\r\n            \"nameLevel4\": null,\r\n            \"nameLevel5\": null,\r\n            \"nameLevel6\": null\r\n          },\r\n          {\r\n            \"idTaxonomy\": \"3559602975575311154\",\r\n            \"code\": \"LV-6800\",\r\n            \"term\": \"Pediatrics\",\r\n            \"nameLevel1\": \"Health Care\",\r\n            \"nameLevel2\": \"Specialty Medicine\",\r\n            \"nameLevel3\": \"Pediatrics\",\r\n            \"nameLevel4\": null,\r\n            \"nameLevel5\": null,\r\n            \"nameLevel6\": null\r\n          },\r\n          {\r\n            \"idTaxonomy\": \"7268255179917805250\",\r\n            \"code\": \"LT-3400.2500\",\r\n            \"term\": \"General Immunization\",\r\n            \"nameLevel1\": \"Health Care\",\r\n            \"nameLevel2\": \"Specialized Treatment and Prevention\",\r\n            \"nameLevel3\": \"Immunizations\",\r\n            \"nameLevel4\": \"General Immunization\",\r\n            \"nameLevel5\": null,\r\n            \"nameLevel6\": null\r\n          }\r\n        ],\r\n        \"category\": null,\r\n        \"serviceAtLocation\": [\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T0000017LiLQAU\",\r\n            \"idLocation\": \"211colorad-a014T000006GO6UQAW\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000002u03bQAA\",\r\n            \"idLocation\": \"211colorad-a014T000003RADTQA4\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000002u7F5QAI\",\r\n            \"idLocation\": \"211colorad-a014T000003RPonQAG\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVnbQAE\",\r\n            \"idLocation\": \"211colorad-a014T000004ehE9QAI\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVncQAE\",\r\n            \"idLocation\": \"211colorad-a014T000004ehEEQAY\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVngQAE\",\r\n            \"idLocation\": \"211colorad-a014T000004ehEYQAY\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVnWQAU\",\r\n            \"idLocation\": \"211colorad-a014T000004ehCZQAY\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          },\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVnXQAU\",\r\n            \"idLocation\": \"211colorad-a014T000004ehCjQAI\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          }\r\n        ],\r\n        \"temporaryMessage\": null,\r\n        \"createdOn\": null,\r\n        \"lastUpdated\": null,\r\n        \"lastVerified\": null\r\n      }\r\n    ],\r\n    \"locations\": [\r\n      {\r\n        \"idLocation\": \"211colorad-a014T000004ehEEQAY\",\r\n        \"name\": null,\r\n        \"alternateName\": \"NextCare Urgent Care - Broomfield\",\r\n        \"description\": \"<p>Provides medical care.</p>\",\r\n        \"transportation\": null,\r\n        \"latitude\": \"39.915035\",\r\n        \"longitude\": \"-105.045715\",\r\n        \"schedule\": \"Monday - Friday, 8 a.m. - 8 p.m.; Saturday, Sunday, 9 a.m. - 4 p.m.\",\r\n        \"address\": [\r\n          {\r\n            \"idAddress\": \"7751185733853289394\",\r\n            \"type\": \"physical\",\r\n            \"address_1\": \"4590 W 121st Ave\",\r\n            \"address_2\": null,\r\n            \"city\": \"Broomfield\",\r\n            \"region\": \"Broomfield County\",\r\n            \"state_province\": \"CO\",\r\n            \"zipcode\": \"80020\",\r\n            \"country\": \"United States\"\r\n          }\r\n        ],\r\n        \"accessibility\": \"Yes (Accessible Bathroom;Designated Parking)\",\r\n        \"language\": null,\r\n        \"phone\": [\r\n          {\r\n            \"idPhone\": \"3380791123448311933\",\r\n            \"number\": \"(303) 439-4544\",\r\n            \"extension\": null,\r\n            \"type\": \"Main\",\r\n            \"description\": null,\r\n            \"name\": null\r\n          }\r\n        ],\r\n        \"serviceAtLocation\": [\r\n          {\r\n            \"idServiceAtLocation\": \"211colorad-a0h4T000003fVncQAE\",\r\n            \"idLocation\": \"211colorad-a014T000004ehEEQAY\",\r\n            \"idService\": \"211colorad-a0E4T000000NjbOUAS\"\r\n          }\r\n        ]\r\n      }\r\n    ],\r\n    \"source\": \"211 Colorado\",\r\n    \"createdOn\": null,\r\n    \"lastUpdated\": null,\r\n    \"lastVerified\": null,\r\n    \"partitionKey\": \"LN-8500\",\r\n    \"id\": null,\r\n    \"_rid\": null,\r\n    \"_self\": null,\r\n    \"_etag\": null,\r\n    \"_attachments\": null\r\n  }\r\n]"
+        }
+      },
+      "recorded_at": "Sat, 16 Sep 2023 18:31:40 GMT"
     }
   ],
   "recorded_with": "VCR 6.2.0"

--- a/spec/poros/detailed_providers_spec.rb
+++ b/spec/poros/detailed_providers_spec.rb
@@ -33,16 +33,6 @@ RSpec.describe DetailedProvider, type: :poros do
                           :document=>"None",
                           :contact=>[],
                           :phone=>[{:idPhone=>"8996837316245339326", :number=>"(800) 244-0680", :extension=>nil, :type=>"main number", :description=>nil, :name=>nil}],
-                          :taxonomy=>
-                            [{:idTaxonomy=>"7880547121544954498",
-                              :code=>"LT-2600.1500",
-                              :term=>"Dialysis Centers",
-                              :nameLevel1=>"Health Care",
-                              :nameLevel2=>"Specialized Treatment and Prevention",
-                              :nameLevel3=>"Hemodialysis",
-                              :nameLevel4=>"Dialysis Centers",
-                              :nameLevel5=>nil,
-                              :nameLevel6=>nil}],
                           :category=>nil,
                           :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
                           :temporaryMessage=>nil,
@@ -79,15 +69,7 @@ RSpec.describe DetailedProvider, type: :poros do
                             [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
                             {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
                         :source=>"211 Contra Costa",
-                        :createdOn=>nil,
-                        :lastUpdated=>nil,
-                        :lastVerified=>nil,
-                        :partitionKey=>"LT-2600.1500",
-                        :id=>nil,
-                        :_rid=>nil,
-                        :_self=>nil,
-                        :_etag=>nil,
-                        :_attachments=>nil}
+                      }
 
         provider = DetailedProvider.new(symbolized_data)
 
@@ -105,6 +87,149 @@ RSpec.describe DetailedProvider, type: :poros do
         expect(provider.phone).to eq("(800) 244-0680")
         expect(provider.fees).to eq("Varies, according to health plan.")
         expect(provider.schedule).to eq("Monday-Friday, 5am-6:30pm; Saturday: 7-11am")
+    end
+
+    it 'can get the phone number from the location (if available)' do
+      symbolized_data = {:idOrganization=>"211contrac-213",
+                          :name=>"DAVITA HEALTHCARE PARTNERS",
+                          :alternateName=>nil,
+                          :description=>
+                          "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                          :url=>"http://www.davita.com",
+                          :taxStatus=>nil,
+                          :taxId=>"None",
+                          :yearIncorporated=>nil,
+                          :legalStatus=>"For Profit",
+                          :services=>
+                          [{:idService=>"211contrac-1561",
+                            :idOrganization=>"211contrac-213",
+                            :name=>"DAVITA HEALTHCARE PARTNERS (DIALYSIS CENTERS)",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :email=>nil,
+                            :url=>"http://www.davita.com",
+                            :status=>"active",
+                            :applicationProcess=>"Call for information or use website to locate dialysis clinics by city and/or zip code",
+                            :waitTime=>nil,
+                            :fees=>"Varies, according to health plan.",
+                            :accreditations=>nil,
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :language=>"English only",
+                            :eligibility=>"Anyone in need of dialysis",
+                            :document=>"None",
+                            :contact=>[],
+                            :phone=>[{:idPhone=>"8996837316245339326", :number=>"(800) 244-0680", :extension=>nil, :type=>"main number", :description=>nil, :name=>nil}],
+                            :category=>nil,
+                            :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
+                            :temporaryMessage=>nil,
+                            :createdOn=>nil,
+                            :lastUpdated=>nil,
+                            :lastVerified=>nil}],
+                          :locations=>
+                          [{:idLocation=>"211contrac-1617",
+                            :name=>"DAVITA HEALTHCARE PARTNERS",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient d
+                        ialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :transportation=>nil,
+                            :latitude=>"39.753627",
+                            :longitude=>"-105.003635",
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :address=>
+                              [{:idAddress=>"2509270918712944620",
+                                :type=>"physical",
+                                :address_1=>"2000 16th Street",
+                                :address_2=>nil,
+                                :city=>"Denver",
+                                :region=>"Denver",
+                                :state_province=>"CO",
+                                :zipcode=>"80202",
+                                :country=>"United States"}],
+                            :accessibility=>nil,
+                            :language=>nil,
+                            :phone=>
+                              [{:idPhone=>"4429686088590907983", :number=>"(800) 424-6589", :extension=>nil, :type=>"Backdoor Number", :description=>nil, :name=>nil},
+                              {:idPhone=>"6719860891525450389", :number=>"(800) 244-0680", :extension=>nil, :type=>"Main Number", :description=>nil, :name=>nil}],
+                            :serviceAtLocation=>
+                              [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
+                              {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
+                          :source=>"211 Contra Costa",
+                        }
+      provider = DetailedProvider.new(symbolized_data)
+              
+      expect(provider.phone).to eq("(800) 244-0680")
+    end
+
+    it 'returns message if number is not available' do
+      symbolized_data = {:idOrganization=>"211contrac-213",
+                          :name=>"DAVITA HEALTHCARE PARTNERS",
+                          :alternateName=>nil,
+                          :description=>
+                          "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                          :url=>"http://www.davita.com",
+                          :taxStatus=>nil,
+                          :taxId=>"None",
+                          :yearIncorporated=>nil,
+                          :legalStatus=>"For Profit",
+                          :services=>
+                          [{:idService=>"211contrac-1561",
+                            :idOrganization=>"211contrac-213",
+                            :name=>"DAVITA HEALTHCARE PARTNERS (DIALYSIS CENTERS)",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :email=>nil,
+                            :url=>"http://www.davita.com",
+                            :status=>"active",
+                            :applicationProcess=>"Call for information or use website to locate dialysis clinics by city and/or zip code",
+                            :waitTime=>nil,
+                            :fees=>"Varies, according to health plan.",
+                            :accreditations=>nil,
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :language=>"English only",
+                            :eligibility=>"Anyone in need of dialysis",
+                            :document=>"None",
+                            :contact=>[],
+                            :category=>nil,
+                            :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
+                            :temporaryMessage=>nil,
+                            :createdOn=>nil,
+                            :lastUpdated=>nil,
+                            :lastVerified=>nil}],
+                          :locations=>
+                          [{:idLocation=>"211contrac-1617",
+                            :name=>"DAVITA HEALTHCARE PARTNERS",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient d
+                        ialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :transportation=>nil,
+                            :latitude=>"39.753627",
+                            :longitude=>"-105.003635",
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :address=>
+                              [{:idAddress=>"2509270918712944620",
+                                :type=>"physical",
+                                :address_1=>"2000 16th Street",
+                                :address_2=>nil,
+                                :city=>"Denver",
+                                :region=>"Denver",
+                                :state_province=>"CO",
+                                :zipcode=>"80202",
+                                :country=>"United States"}],
+                            :accessibility=>nil,
+                            :language=>nil,
+                            :serviceAtLocation=>
+                              [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
+                              {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
+                          :source=>"211 Contra Costa",
+                        }
+                        
+      provider = DetailedProvider.new(symbolized_data)
+
+      expect(provider.phone).to eq("Phone number not available")
     end
   end
 end

--- a/spec/poros/detailed_providers_spec.rb
+++ b/spec/poros/detailed_providers_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe DetailedProvider, type: :poros do
         expect(provider.schedule).to eq("Monday-Friday, 5am-6:30pm; Saturday: 7-11am")
     end
 
-    it 'can get the phone number from the location (if available)' do
+    it 'can get the phone number from the services' do
       symbolized_data = {:idOrganization=>"211contrac-213",
                           :name=>"DAVITA HEALTHCARE PARTNERS",
                           :alternateName=>nil,
@@ -120,6 +120,74 @@ RSpec.describe DetailedProvider, type: :poros do
                             :document=>"None",
                             :contact=>[],
                             :phone=>[{:idPhone=>"8996837316245339326", :number=>"(800) 244-0680", :extension=>nil, :type=>"main number", :description=>nil, :name=>nil}],
+                            :category=>nil,
+                            :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
+                            :temporaryMessage=>nil,
+                            :createdOn=>nil,
+                            :lastUpdated=>nil,
+                            :lastVerified=>nil}],
+                          :locations=>
+                          [{:idLocation=>"211contrac-1617",
+                            :name=>"DAVITA HEALTHCARE PARTNERS",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient d
+                        ialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :transportation=>nil,
+                            :latitude=>"39.753627",
+                            :longitude=>"-105.003635",
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :address=>
+                              [{:idAddress=>"2509270918712944620",
+                                :type=>"physical",
+                                :address_1=>"2000 16th Street",
+                                :address_2=>nil,
+                                :city=>"Denver",
+                                :region=>"Denver",
+                                :state_province=>"CO",
+                                :zipcode=>"80202",
+                                :country=>"United States"}],
+                            :accessibility=>nil,
+                            :language=>nil,
+                            :serviceAtLocation=>
+                              [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
+                              {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
+                          :source=>"211 Contra Costa",
+                        }
+      provider = DetailedProvider.new(symbolized_data)
+              
+      expect(provider.phone).to eq("(800) 244-0680")
+    end
+    it 'can get the phone number from the location' do
+      symbolized_data = {:idOrganization=>"211contrac-213",
+                          :name=>"DAVITA HEALTHCARE PARTNERS",
+                          :alternateName=>nil,
+                          :description=>
+                          "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                          :url=>"http://www.davita.com",
+                          :taxStatus=>nil,
+                          :taxId=>"None",
+                          :yearIncorporated=>nil,
+                          :legalStatus=>"For Profit",
+                          :services=>
+                          [{:idService=>"211contrac-1561",
+                            :idOrganization=>"211contrac-213",
+                            :name=>"DAVITA HEALTHCARE PARTNERS (DIALYSIS CENTERS)",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :email=>nil,
+                            :url=>"http://www.davita.com",
+                            :status=>"active",
+                            :applicationProcess=>"Call for information or use website to locate dialysis clinics by city and/or zip code",
+                            :waitTime=>nil,
+                            :fees=>"Varies, according to health plan.",
+                            :accreditations=>nil,
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :language=>"English only",
+                            :eligibility=>"Anyone in need of dialysis",
+                            :document=>"None",
+                            :contact=>[],
                             :category=>nil,
                             :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
                             :temporaryMessage=>nil,
@@ -230,108 +298,6 @@ RSpec.describe DetailedProvider, type: :poros do
       provider = DetailedProvider.new(symbolized_data)
 
       expect(provider.phone).to eq("Phone number not available")
-    end
-
-    context '#get_phone method unit tests' do
-      it 'can return service phone number' do
-        data = {:idOrganization=>"211contrac-213",
-                :name=>"DAVITA HEALTHCARE PARTNERS",
-                :alternateName=>nil,
-                :description=>
-                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
-                :url=>"http://www.davita.com",
-                :taxStatus=>nil,
-                :taxId=>"None",
-                :yearIncorporated=>nil,
-                :legalStatus=>"For Profit",
-                :services=>
-                [{:idService=>"211contrac-1561",
-                  :idOrganization=>"211contrac-213",
-                  :name=>"DAVITA HEALTHCARE PARTNERS (DIALYSIS CENTERS)",
-                  :alternateName=>nil,
-                  :description=>
-                    "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
-                  :email=>nil,
-                  :url=>"http://www.davita.com",
-                  :status=>"active",
-                  :applicationProcess=>"Call for information or use website to locate dialysis clinics by city and/or zip code",
-                  :waitTime=>nil,
-                  :fees=>"Varies, according to health plan.",
-                  :accreditations=>nil,
-                  :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
-                  :language=>"English only",
-                  :eligibility=>"Anyone in need of dialysis",
-                  :document=>"None",
-                  :contact=>[],
-                  :phone=>[{:idPhone=>"8996837316245339326", :number=>"(800) 244-0680", :extension=>nil, :type=>"main number", :description=>nil, :name=>nil}],
-                  :category=>nil,
-                  :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
-                  :temporaryMessage=>nil,
-                  :createdOn=>nil,
-                  :lastUpdated=>nil,
-                  :lastVerified=>nil}]}
-
-        expect(get_phone(data)).to eq("(800) 244-0680")
-      end
-
-      it 'can return a location phone number' do
-        data = {:idOrganization=>"211contrac-213",
-                :name=>"DAVITA HEALTHCARE PARTNERS",
-                :alternateName=>nil,
-                :description=>
-                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
-                :url=>"http://www.davita.com",
-                :taxStatus=>nil,
-                :taxId=>"None",
-                :yearIncorporated=>nil,
-                :legalStatus=>"For Profit",
-                :locations=>
-                          [{:idLocation=>"211contrac-1617",
-                            :name=>"DAVITA HEALTHCARE PARTNERS",
-                            :alternateName=>nil,
-                            :description=>
-                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
-                            :transportation=>nil,
-                            :latitude=>"39.753627",
-                            :longitude=>"-105.003635",
-                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
-                            :address=>
-                              [{:idAddress=>"2509270918712944620",
-                                :type=>"physical",
-                                :address_1=>"2000 16th Street",
-                                :address_2=>nil,
-                                :city=>"Denver",
-                                :region=>"Denver",
-                                :state_province=>"CO",
-                                :zipcode=>"80202",
-                                :country=>"United States"}],
-                            :accessibility=>nil,
-                            :language=>nil,
-                            :phone=>
-                              [{:idPhone=>"4429686088590907983", :number=>"(800) 424-6589", :extension=>nil, :type=>"Backdoor Number", :description=>nil, :name=>nil},
-                              {:idPhone=>"6719860891525450389", :number=>"(800) 244-0680", :extension=>nil, :type=>"Main Number", :description=>nil, :name=>nil}],
-                            :serviceAtLocation=>
-                              [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
-                              {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
-                          :source=>"211 Contra Costa",
-                        }
-        expect(get_phone(data)).to eq("(800) 244-0680")
-      end
-
-      it 'returns message if no numbers available' do
-        data = {:idOrganization=>"211contrac-213",
-                :name=>"DAVITA HEALTHCARE PARTNERS",
-                :alternateName=>nil,
-                :description=>
-                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
-                :url=>"http://www.davita.com",
-                :taxStatus=>nil,
-                :taxId=>"None",
-                :yearIncorporated=>nil,
-                :legalStatus=>"For Profit"
-              }
-        expect(get_phone(data)).to eq("Phone number not available")
-      end
     end
   end
 end

--- a/spec/poros/detailed_providers_spec.rb
+++ b/spec/poros/detailed_providers_spec.rb
@@ -226,10 +226,112 @@ RSpec.describe DetailedProvider, type: :poros do
                               {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
                           :source=>"211 Contra Costa",
                         }
-                        
+
       provider = DetailedProvider.new(symbolized_data)
 
       expect(provider.phone).to eq("Phone number not available")
+    end
+
+    context '#get_phone method unit tests' do
+      it 'can return service phone number' do
+        data = {:idOrganization=>"211contrac-213",
+                :name=>"DAVITA HEALTHCARE PARTNERS",
+                :alternateName=>nil,
+                :description=>
+                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                :url=>"http://www.davita.com",
+                :taxStatus=>nil,
+                :taxId=>"None",
+                :yearIncorporated=>nil,
+                :legalStatus=>"For Profit",
+                :services=>
+                [{:idService=>"211contrac-1561",
+                  :idOrganization=>"211contrac-213",
+                  :name=>"DAVITA HEALTHCARE PARTNERS (DIALYSIS CENTERS)",
+                  :alternateName=>nil,
+                  :description=>
+                    "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                  :email=>nil,
+                  :url=>"http://www.davita.com",
+                  :status=>"active",
+                  :applicationProcess=>"Call for information or use website to locate dialysis clinics by city and/or zip code",
+                  :waitTime=>nil,
+                  :fees=>"Varies, according to health plan.",
+                  :accreditations=>nil,
+                  :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                  :language=>"English only",
+                  :eligibility=>"Anyone in need of dialysis",
+                  :document=>"None",
+                  :contact=>[],
+                  :phone=>[{:idPhone=>"8996837316245339326", :number=>"(800) 244-0680", :extension=>nil, :type=>"main number", :description=>nil, :name=>nil}],
+                  :category=>nil,
+                  :serviceAtLocation=>[{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"}],
+                  :temporaryMessage=>nil,
+                  :createdOn=>nil,
+                  :lastUpdated=>nil,
+                  :lastVerified=>nil}]}
+
+        expect(get_phone(data)).to eq("(800) 244-0680")
+      end
+
+      it 'can return a location phone number' do
+        data = {:idOrganization=>"211contrac-213",
+                :name=>"DAVITA HEALTHCARE PARTNERS",
+                :alternateName=>nil,
+                :description=>
+                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                :url=>"http://www.davita.com",
+                :taxStatus=>nil,
+                :taxId=>"None",
+                :yearIncorporated=>nil,
+                :legalStatus=>"For Profit",
+                :locations=>
+                          [{:idLocation=>"211contrac-1617",
+                            :name=>"DAVITA HEALTHCARE PARTNERS",
+                            :alternateName=>nil,
+                            :description=>
+                              "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                            :transportation=>nil,
+                            :latitude=>"39.753627",
+                            :longitude=>"-105.003635",
+                            :schedule=>"Monday-Friday, 5am-6:30pm; Saturday: 7-11am",
+                            :address=>
+                              [{:idAddress=>"2509270918712944620",
+                                :type=>"physical",
+                                :address_1=>"2000 16th Street",
+                                :address_2=>nil,
+                                :city=>"Denver",
+                                :region=>"Denver",
+                                :state_province=>"CO",
+                                :zipcode=>"80202",
+                                :country=>"United States"}],
+                            :accessibility=>nil,
+                            :language=>nil,
+                            :phone=>
+                              [{:idPhone=>"4429686088590907983", :number=>"(800) 424-6589", :extension=>nil, :type=>"Backdoor Number", :description=>nil, :name=>nil},
+                              {:idPhone=>"6719860891525450389", :number=>"(800) 244-0680", :extension=>nil, :type=>"Main Number", :description=>nil, :name=>nil}],
+                            :serviceAtLocation=>
+                              [{:idServiceAtLocation=>"211contrac-1561", :idLocation=>"211contrac-1617", :idService=>"211contrac-1561"},
+                              {:idServiceAtLocation=>"211contrac-1562", :idLocation=>"211contrac-1617", :idService=>"211contrac-1562"}]}],
+                          :source=>"211 Contra Costa",
+                        }
+        expect(get_phone(data)).to eq("(800) 244-0680")
+      end
+
+      it 'returns message if no numbers available' do
+        data = {:idOrganization=>"211contrac-213",
+                :name=>"DAVITA HEALTHCARE PARTNERS",
+                :alternateName=>nil,
+                :description=>
+                "Provides dialysis services for those diagnosed with chronic kidney failure, a condition also known as chronic kidney disease (CKD). Provides locations of over 2,000 outpatient dialysis facilities and acute units in over 800 hospitals 46 states and the District of Columbia. Website offers extensive information about CKD.",
+                :url=>"http://www.davita.com",
+                :taxStatus=>nil,
+                :taxId=>"None",
+                :yearIncorporated=>nil,
+                :legalStatus=>"For Profit"
+              }
+        expect(get_phone(data)).to eq("Phone number not available")
+      end
     end
   end
 end

--- a/spec/requests/api/v0/provider_details_spec.rb
+++ b/spec/requests/api/v0/provider_details_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'Search', type: :request do
   describe 'GET /api/v0/provider_details/:id', :vcr do
     context 'When a valid ID is used' do
       it 'should return the details of a provider' do
-        provider_id = "211contrac-1561"
-
+        provider_id = "211colorad-a0h4T000003fVncQAE"
+        
         get "/api/v0/provider_details/#{provider_id}"
 
         expect(response).to be_successful


### PR DESCRIPTION
### Description of changes
- Updates Provider Details api request test with an new service that has phone numbers located in a different place
- Adds unit and integration tests for new methods to find phone numbers from the 211 API response
- Adds methods to the Detailed Provider PORO to find a phone number from multiple places it could be located or return message if none are available from the API pull. 

### Test Suite
- [x] Are all tests within the test suite passing?

### Specific Feedback Request(s)

#### Add GIF (NOT Optional)

![giphy (1)](https://github.com/westonio/next-steps-back-end/assets/117330008/d3ec350f-2f80-47c7-8c23-efa23d3f3c58)
